### PR TITLE
Pin Hugging Face Hub download revision (security)

### DIFF
--- a/src/mlxim/model/_utils.py
+++ b/src/mlxim/model/_utils.py
@@ -128,11 +128,21 @@ def load_weights(model: nn.Module, weights: str, strict: bool = True, verbose: b
     return model
 
 
-def download_from_hf(model_name: str, repo_id: str | None = None, filename: str | None = None) -> str:
+def download_from_hf(
+    model_name: str,
+    repo_id: str | None = None,
+    filename: str | None = None,
+    revision: str = "main",
+) -> str:
     """Download weights from HuggingFace Hub.
 
     Args:
         model_name (str): model name
+        repo_id (str | None): override repo_id from MODEL_CONFIG
+        filename (str | None): override filename from MODEL_CONFIG
+        revision (str): HF Hub revision (branch, tag, or commit SHA) to pin
+            the download. Defaults to "main" — pass an explicit commit SHA
+            for reproducible model loads.
 
     Returns:
         str: path to downloaded weights
@@ -145,7 +155,7 @@ def download_from_hf(model_name: str, repo_id: str | None = None, filename: str 
     assert filename is not None, f"filename required for {model_name}"
     print(f"Downloading weights for {model_name} from HuggingFace Hub.")
     try:
-        weights_path = hf_hub_download(repo_id=repo_id, repo_type="model", filename=filename)
+        weights_path = hf_hub_download(repo_id=repo_id, repo_type="model", filename=filename, revision=revision)
     except Exception as e:
         raise RuntimeError(f"Downloading weights from HuggingFace Hub failed for {model_name}: {e}") from e
 


### PR DESCRIPTION
## Summary

`download_from_hf()` calls `hf_hub_download(...)` without passing a `revision`, so every download silently floats to whatever `main` points at right now. This patch threads a `revision` parameter through (default `"main"` for backward compatibility) so callers can pin to an exact commit SHA for reproducible model loads.

Resolves bandit B615 _"Unsafe Hugging Face Hub download without revision pinning"_.

## Why this matters

Without explicit pinning, the same `mlxim.create_model(...)` call can return different weights at different times if the upstream HF repo gets a new commit on `main` (typo fix, README change, or a deliberate weight update). Downstream metrics drift silently. With this change you can pass an SHA to lock things down:

```python
download_from_hf("vit_base_patch16_224", revision="abc123def456")
```

## Backwards compatibility

Default value is `"main"` — same as the previous implicit behavior. No existing call site needs to change.

## Test plan

- [ ] `bandit -r src/ --severity-level medium` reports 0 issues for `_utils.py`
- [ ] `mlxim.create_model("vit_base_patch16_224")` still loads correctly (default revision)
- [ ] Passing `revision="<sha>"` returns weights from that exact commit